### PR TITLE
Added support for stdout and stderr

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ set -e -x
 
 cd $(dirname $0)
 
-docker build -t dispatchframework/powershell-base:0.0.3 .
+docker build -t dispatchframework/powershell-base:0.0.4 .


### PR DESCRIPTION
* Captures stdout as: `Write-Host, Write-Information, Write-Verbose, Write-Debug`
* Captures stderr as: `Write-Error, Write-Warning`
* Doesn't seem possible to capture `Write-Progress` since it's always outputted to the console
* Because of how powershell deals with output, it's not possible to capture everything such as
```
function handle($context, $payload) {
    "Simple text return"
    Write-Output "Write-Output message"
    return "payload"
}
```
This will return the result to be an array `["Simple text return", "Write-Output message", "payload"]`. Since powershell treats anything uncaptured as output, everything is returned as output and it doesn't seem possible to separate it out.