### PR TITLE
Single file functions without handler arg and fix unit tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ WORKDIR ${WORKDIR}
 
 COPY ./index.ps1 /root
 
-CMD ["pwsh", "-NoLogo", "-File", "/root/index.ps1"]
+CMD pwsh -NoLogo -File /root/index.ps1 $(cat /tmp/handler)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # powershell-base-image
 PowerShell language support for Dispatch
 
-Latest image [on Docker Hub](https://hub.docker.com/r/dispatchframework/powershell-base/): `dispatchframework/powershell-base:0.0.7`
+Latest image [on Docker Hub](https://hub.docker.com/r/dispatchframework/powershell-base/): `dispatchframework/powershell-base:0.0.8`
 
 ## Usage
 
@@ -11,7 +11,7 @@ You need a recent version of Dispatch [installed in your Kubernetes cluster, Dis
 
 To add the base-image to Dispatch:
 ```bash
-$ dispatch create base-image powershell-base dispatchframework/powershell-base:0.0.7
+$ dispatch create base-image powershell-base dispatchframework/powershell-base:0.0.8
 ```
 
 Make sure the base-image status is `READY` (it normally goes from `INITIALIZED` to `READY`):

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,4 @@ set -e -x
 
 cd $(dirname $0)
 
-docker build -t dispatchframework/powershell-base:0.0.7 .
+docker build -t dispatchframework/powershell-base:0.0.8 .

--- a/function-template/Dockerfile
+++ b/function-template/Dockerfile
@@ -1,9 +1,16 @@
 ARG IMAGE
 FROM ${IMAGE}
 
-ARG HANDLER=handler.ps1::handle
+ARG HANDLER
 ENV HANDLER=$HANDLER
 
 WORKDIR ${WORKDIR}
 
 COPY . .
+
+# Create handler file if passed in otherwise assume default handler
+RUN echo -n ${HANDLER} > /tmp/handler
+RUN [ -z "${HANDLER}" ] && \
+    [ $(ls *.ps1 | wc -l) -eq "1" ] && \
+    filename=$(ls *.ps1) && \
+    { echo -n $filename; echo -n "::handle"; } > /tmp/handler || :

--- a/index.ps1
+++ b/index.ps1
@@ -1,4 +1,9 @@
-$scriptFile, $func = $Env:HANDLER.split('::')
+Param(
+    [Parameter(Mandatory=$True, Position=0)]
+    [string]$handler
+)
+
+$scriptFile, $func = $handler.split('::')
 
 . $PSScriptRoot\function\$scriptFile
 

--- a/index.tests.ps1
+++ b/index.tests.ps1
@@ -1,4 +1,4 @@
-. .\index.ps1
+. .\index.ps1 handler.ps1::handle
 
 Describe 'index tests' {
     Context 'getRequestBody' {


### PR DESCRIPTION
* Can create functions with single file without specifying the `--handler` argument if the file has a `handle` function
* Fix unit test import